### PR TITLE
Resolve potential issue for unserializable value

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,7 +7,7 @@ chrome.action.onClicked.addListener((tab) => {
     chrome.scripting.executeScript(
       {
         target: { tabId: tab.id },
-        args: [darkModeActive],
+        args: [darkModeActive ? true : false],
         function: showPopup,
       },
       () => chrome.runtime.lastError


### PR DESCRIPTION
When passing `darkModeActive` into `args`, chromium variants may create an error claiming that the value is unserializable.

Explicitly using true or false boolean values would resolve this issue.